### PR TITLE
Add vintf_fragments to android.hardware.usb@1.0-service.basic

### DIFF
--- a/usb/1.0-basic/Android.bp
+++ b/usb/1.0-basic/Android.bp
@@ -17,6 +17,7 @@ cc_binary {
     name: "android.hardware.usb@1.0-service.basic",
     relative_install_path: "hw",
     init_rc: ["android.hardware.usb@1.0-service.basic.rc"],
+    vintf_fragments: ["android.hardware.usb@1.0-service.basic.xml"],
     srcs: ["service.cpp", "Usb.cpp"],
     shared_libs: [
         "libbase",

--- a/usb/1.0-basic/android.hardware.usb@1.0-service.basic.xml
+++ b/usb/1.0-basic/android.hardware.usb@1.0-service.basic.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.usb</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IUsb</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
Service android.hardware.usb@1.0::IUsb/default must be in VINTF manifest in order to register/get.